### PR TITLE
Support Submodules

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -26,6 +26,15 @@ module Git
       }.merge(opts)
       
       FileUtils.mkdir_p(opts[:working_directory]) if opts[:working_directory] && !File.directory?(opts[:working_directory])
+
+      # Submodules have a .git *file* not a .git folder.
+      # This file's contents point to the location of
+      # where the git refs are held (In the parent repo)
+      if File.file?('.git')
+        git_file = File.open('.git').read[8..-1].strip
+        opts[:repository] = git_file
+        opts[:index] = git_file + '/index'
+      end
       
       # run git_init there
       Git::Lib.new(opts).init


### PR DESCRIPTION
When a submodule is cloned into another project, it has a different structure:

The .git folder is well, not a folder, it is a file that's sole contents
include a reference to where the .git folder for the submodule is on the
local drive.

Take that information from the .git *file* and then build our repository
and index location out of this.