### PR TITLE
additional test for branch#create method

### DIFF
--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -54,6 +54,7 @@ class TestBranch < Test::Unit::TestCase
       Dir.chdir('branch_test') do
         assert(!g.branch('new_branch').current)
         g.branch('other_branch').create
+        assert(!g.branch('other_branch').current)
         g.branch('new_branch').checkout
         assert(g.branch('new_branch').current)
 


### PR DESCRIPTION
Just one additional assertion for `branch#create` to check that it does not switch branch (tests pass even when `git checkout -b` is used instead of `git branch`: https://github.com/schacon/ruby-git/pull/119)