### PR TITLE
Test Unit needs specificity

### DIFF
--- a/git.gemspec
+++ b/git.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'test-unit', '>= 2.2', '< 4'
+  s.add_development_dependency 'test-unit', '>=2', '< 4', '!=2.1.1.0'
   
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options = ['--charset=UTF-8']

--- a/git.gemspec
+++ b/git.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'test-unit', '~>2.2'
+  s.add_development_dependency 'test-unit', '>= 2.2', '< 4'
   
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options = ['--charset=UTF-8']

--- a/git.gemspec
+++ b/git.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'test-unit'
+  s.add_development_dependency 'test-unit', '~>3'
   
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options = ['--charset=UTF-8']

--- a/git.gemspec
+++ b/git.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'test-unit', '~>3'
+  s.add_development_dependency 'test-unit', '~>2.2'
   
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options = ['--charset=UTF-8']


### PR DESCRIPTION
If you try to run the tests under test-unit ~>2.0 you will get a no
method error for teardown. This is apparently a test-unit 3.0 method as
upgrading test-unit fixed the error.