### PR TITLE
Git::Diff - don't convert to empty string if from/to is nil

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -6,8 +6,11 @@ module Git
     
     def initialize(base, from = nil, to = nil)
       @base = base
-      @from = from.to_s
-      @to = to.to_s
+      # don't convert to empty string if from/to is nil
+      @from = nil
+      @to = nil
+      @from = from.to_s if from
+      @to = to.to_s if to
 
       @path = nil
       @full_diff = nil

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -14,6 +14,14 @@ class TestDiff < Test::Unit::TestCase
   #  assert(1, d.size)
   #end
 
+  def test_diff_current_vs_head
+    #test git diff without specifying source/destination commits
+    update_file(File.join(@wdir,"example.txt"),"FRANCO")
+    d = @git.diff
+    patch = d.patch
+    assert(patch.match(/\+FRANCO/))
+  end
+
   def test_diff_tags
     d = @git.diff('gitsearch1', 'v2.5')
     assert_equal(3, d.size)


### PR DESCRIPTION
I was having trouble just getting the code to do a git diff without specifying commits.  

```
I, [2014-09-26T16:21:18.444662 #65864]  INFO -- : git diff '-p' 'HEAD' ''  2>&1
D, [2014-09-26T16:21:18.444727 #65864] DEBUG -- : fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
/Users/fluong/.rvm/gems/ruby-2.0.0-p353/gems/git-1.2.8/lib/git/lib.rb:764:in `command': git diff '-p' 'HEAD' ''  2>&1:fatal: ambiguous argument '': unknown revision or path not in the working tree. (Git::GitExecuteError)
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
	from /Users/fluong/.rvm/gems/ruby-2.0.0-p353/gems/git-1.2.8/lib/git/lib.rb:276:in `diff_full'
	from /Users/fluong/.rvm/gems/ruby-2.0.0-p353/gems/git-1.2.8/lib/git/diff.rb:100:in `cache_full'
	from /Users/fluong/.rvm/gems/ruby-2.0.0-p353/gems/git-1.2.8/lib/git/diff.rb:51:in `patch'
	from ./git-diff.rb:9:in `<main>'
```

I think this will fix it.