### PR TITLE
Fix the encoding issue - 'split': invalid byte sequence in UTF-8 (Argument Error)

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -118,7 +118,7 @@ module Git
       def process_full_diff
         final = {}
         current_file = nil
-	full_diff_utf8_encoded = @full_diff.encode("UTF-8", "binary", invalid: :replace, undef: :replace)
+	full_diff_utf8_encoded = @full_diff.encode("UTF-8", "binary", :invalid => "replace", :undef => "replace")
 	full_diff_utf8_encoded.split("\n").each do |line|
           if m = /diff --git a\/(.*?) b\/(.*?)/.match(line)
             current_file = m[1]

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -118,7 +118,8 @@ module Git
       def process_full_diff
         final = {}
         current_file = nil
-        @full_diff.split("\n").each do |line|
+	full_diff_utf8_encoded = @full_diff.encode("UTF-8", "binary", invalid: :replace, undef: :replace)
+	full_diff_utf8_encoded.split("\n").each do |line|
           if m = /diff --git a\/(.*?) b\/(.*?)/.match(line)
             current_file = m[1]
             final[current_file] = {:patch => line, :path => current_file, 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -730,7 +730,9 @@ module Git
     private
     
     def command_lines(cmd, opts = [], chdir = true, redirect = '')
-      command(cmd, opts, chdir).split("\n")
+      cmd_op = command(cmd, opts, chdir)
+      op = cmd_op.encode("UTF-8", "binary", invalid: :replace, undef: :replace)
+      op.split("\n")
     end
     
     def command(cmd, opts = [], chdir = true, redirect = '', &block)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -731,7 +731,7 @@ module Git
     
     def command_lines(cmd, opts = [], chdir = true, redirect = '')
       cmd_op = command(cmd, opts, chdir)
-      op = cmd_op.encode("UTF-8", "binary", invalid: :replace, undef: :replace)
+      op = cmd_op.encode("UTF-8", "binary", :invalid => "replace", :undef => "replace")
       op.split("\n")
     end
     


### PR DESCRIPTION
Fix for the issue I created  - [Ruby-git Issue #188 'split': invalid byte sequence in UTF-8 (Argument Error)](https://github.com/schacon/ruby-git/issues/188)

