### PR TITLE
fix git ssh env usage

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -866,7 +866,7 @@ module Git
       ENV['GIT_DIR'] = @git_dir
       ENV['GIT_WORK_TREE'] = @git_work_dir
       ENV['GIT_INDEX_FILE'] = @git_index_file
-      ENV['GIT_SSH'] = Git::Base.config.git_ssh
+      ENV.fetch('GIT_SSH', Git::Base.config.git_ssh)
     end
 
     # Runs a block inside an environment with customized ENV variables.

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -66,6 +66,27 @@ class TestLib < Test::Unit::TestCase
     assert_equal(ENV['GIT_INDEX_FILE'],'my_index')
   end
 
+  def test_git_ssh_from_environment_is_passed_to_binary
+    ENV['GIT_SSH'] = 'my/git-ssh-wrapper'
+
+    Dir.mktmpdir do |dir|
+      begin
+        output_path = File.join(dir, 'git_ssh_value')
+        binary_path = File.join(dir, 'git')
+        old_binary_path = Git::Base.config.binary_path
+        Git::Base.config.binary_path = binary_path
+        File.open(binary_path, 'w') { |f|
+          f << "echo $GIT_SSH > #{output_path}"
+        }
+        FileUtils.chmod(0700, binary_path)
+        @lib.checkout('something')
+        assert_equal("my/git-ssh-wrapper\n", File.read(output_path))
+      ensure
+        Git::Base.config.binary_path = old_binary_path
+      end
+    end
+  end
+
   def test_revparse
     assert_equal('1cc8667014381e2788a94777532a788307f38d26', @lib.revparse('1cc8667014381')) # commit
     assert_equal('94c827875e2cadb8bc8d4cdd900f19aa9e8634c7', @lib.revparse('1cc8667014381^{tree}')) #tree


### PR DESCRIPTION
v1.2.8 allowed setting of GIT_SSH to point to SSH wrapper.
v1.2.9 overrides this with value of Git::Base.config.git_ssh.

We are not 100% on the v1.2.8 behavior - whether the config setting or the ENV var should take precedence. 
For our purposes, the ENV var would be preferable.

This is our story in our backlog: https://www.pivotaltracker.com/story/show/86059268.