### PR TITLE
Adding `Git::Diff.name_status` support

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -15,7 +15,11 @@ module Git
       @stats = nil
     end
     attr_reader :from, :to
-    
+   
+    def name_status
+      cache_name_status
+    end
+
     def path(path)
       @path = path
       return self
@@ -96,22 +100,21 @@ module Git
     private
     
       def cache_full
-        unless @full_diff
-          @full_diff = @base.lib.diff_full(@from, @to, {:path_limiter => @path})
-        end
+        @full_diff ||= @base.lib.diff_full(@from, @to, {:path_limiter => @path})
       end
       
       def process_full
-        unless @full_diff_files
-          cache_full
-          @full_diff_files = process_full_diff
-        end
+        return if @full_diff_files
+        cache_full
+        @full_diff_files = process_full_diff
       end
       
       def cache_stats
-        unless @stats
-          @stats = @base.lib.diff_stats(@from, @to, {:path_limiter => @path})
-        end
+        @stats ||=  @base.lib.diff_stats(@from, @to, {:path_limiter => @path})
+      end
+
+      def cache_name_status
+        @name_status ||= @base.lib.diff_name_status(@from, @to, {:path => @path})
       end
       
       # break up @diff_full

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -371,6 +371,20 @@ module Git
       hsh
     end
 
+    def diff_name_status(reference1 = nil, reference2 = nil, opts = {})
+      opts_arr = ['--name-status']
+      opts_arr << reference1 if reference1
+      opts_arr << reference2 if reference2
+
+      opts_arr << '--' << opts[:path] if opts[:path]
+
+      command_lines('diff', opts_arr).inject({}) do |memo, line|
+        status, path = line.split("\t")
+        memo[path] = status
+        memo
+      end
+    end
+
     # compares the index and the working directory
     def diff_files
       diff_as_hash('diff-files')


### PR DESCRIPTION
```ruby
repo.diff.name_status
#=> {"lib/git/lib.rb"=>"M"}

repo.diff('HEAD~3').name_status
#=> {"VERSION"=>"M", "git.gemspec"=>"M", "lib/git/config.rb"=>"M", "lib/git/lib.rb"=>"M", "tests/units/test_config.rb"=>"M", "tests/units/test_lib.rb"=>"M"}

repo.diff("HEAD~2", "HEAD~3").name_status
#=> {"VERSION"=>"M", "git.gemspec"=>"M"}
```