### PR TITLE
Passing block from #push to #command

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -322,11 +322,11 @@ module Git
     #
     #  @git.config('remote.remote-name.push', 'refs/heads/master:refs/heads/master')
     #
-    def push(remote = 'origin', branch = 'master', opts = {})
+    def push(remote = 'origin', branch = 'master', opts = {}, &block)
       # Small hack to keep backwards compatibility with the 'push(remote, branch, tags)' method signature.
       opts = {:tags => opts} if [true, false].include?(opts)
 
-      self.lib.push(remote, branch, opts)
+      self.lib.push(remote, branch, opts, &block)
     end
     
     # merges one or more branches into the current working branch

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -716,7 +716,7 @@ module Git
       command('fetch', arr_opts)
     end
     
-    def push(remote, branch = 'master', opts = {})
+    def push(remote, branch = 'master', opts = {}, &block)
       # Small hack to keep backwards compatibility with the 'push(remote, branch, tags)' method signature.
       opts = {:tags => opts} if [true, false].include?(opts) 
       
@@ -724,8 +724,8 @@ module Git
       arr_opts << '--force'  if opts[:force] || opts[:f]
       arr_opts << remote
 
-      command('push', arr_opts + [branch])
-      command('push', ['--tags'] + arr_opts) if opts[:tags]
+      command('push', arr_opts + [branch], &block)
+      command('push', ['--tags'] + arr_opts, &block) if opts[:tags]
     end
 
     def pull(remote='origin', branch='master')


### PR DESCRIPTION
Hi everyone!
I'm working on a system that deploys my application with dokku, which has the same mechanism for deploying as heroku: just git pushing.

Because the git push command might take a couple minutes and I'd like to know what's going on, I modified the code so `#push` passes the block to `#command`.

From there, `#command` passes it to `#run_command`, which in turn calls `IO.popen`, but that was implemented already.
