### PR TITLE
Add method to abort merge if there are conflicts;

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1,7 +1,7 @@
 require 'git/base/factory'
 
 module Git
-  
+
   class Base
 
     include Git::Base::Factory
@@ -10,7 +10,7 @@ module Git
     def self.bare(git_dir, opts = {})
       self.new({:repository => git_dir}.merge(opts))
     end
-    
+
     # clones a git repository locally
     #
     #  repository - http://repo.or.cz/w/sinatra.git
@@ -20,15 +20,15 @@ module Git
     #   :repository
     #
     #    :bare
-    #   or 
+    #   or
     #    :working_directory
     #    :index_file
     #
     def self.clone(repository, name, opts = {})
-      # run git-clone 
+      # run git-clone
       self.new(Git::Lib.new.clone(repository, name, opts))
     end
-    
+
     # Returns (and initialize if needed) a Git::Config instance
     #
     # @return [Git::Config] the current config instance.
@@ -44,17 +44,17 @@ module Git
     #  :repository
     #
     def self.init(working_dir, opts = {})
-      opts[:working_directory] ||= working_dir 
+      opts[:working_directory] ||= working_dir
       opts[:repository] ||= File.join(opts[:working_directory], '.git')
-      
+
       FileUtils.mkdir_p(opts[:working_directory]) if opts[:working_directory] && !File.directory?(opts[:working_directory])
-      
+
       init_opts = {
         :bare => opts[:bare]
       }
 
       opts.delete(:working_directory) if opts[:bare]
-      
+
       # Submodules have a .git *file* not a .git folder.
       # This file's contents point to the location of
       # where the git refs are held (In the parent repo)
@@ -65,16 +65,16 @@ module Git
       end
 
       Git::Lib.new(opts).init(init_opts)
-       
+
       self.new(opts)
     end
-    
+
     # opens a new Git Project from a working directory
     # you can specify non-standard git_dir and index file in the options
     def self.open(working_dir, opts={})
       self.new({:working_directory => working_dir}.merge(opts))
     end
-    
+
     def initialize(options = {})
       if working_dir = options[:working_directory]
         options[:repository] ||= File.join(working_dir, '.git')
@@ -86,17 +86,17 @@ module Git
       else
         @logger = nil
       end
-     
+
       @working_directory = options[:working_directory] ? Git::WorkingDirectory.new(options[:working_directory]) : nil
-      @repository = options[:repository] ? Git::Repository.new(options[:repository]) : nil 
+      @repository = options[:repository] ? Git::Repository.new(options[:repository]) : nil
       @index = options[:index] ? Git::Index.new(options[:index], false) : nil
     end
-    
+
     # changes current working directory for a block
     # to the git working directory
     #
     # example
-    #  @git.chdir do 
+    #  @git.chdir do
     #    # write files
     #    @git.add
     #    @git.commit('message')
@@ -106,7 +106,7 @@ module Git
         yield dir.path
       end
     end
-    
+
     #g.config('user.name', 'Scott Chacon') # sets value
     #g.config('user.email', 'email@email.com')  # sets value
     #g.config('user.name')  # returns 'Scott Chacon'
@@ -123,14 +123,14 @@ module Git
         lib.config_list
       end
     end
-  
+
     # returns a reference to the working directory
     #  @git.dir.path
     #  @git.dir.writeable?
     def dir
       @working_directory
     end
-    
+
     # returns reference to the git index file
     def index
       @index
@@ -141,24 +141,24 @@ module Git
     def repo
       @repository
     end
-    
+
     # returns the repository size in bytes
     def repo_size
       Dir.chdir(repo.path) do
         return `du -s`.chomp.split.first.to_i
       end
     end
-    
+
     def set_index(index_file, check = true)
       @lib = nil
       @index = Git::Index.new(index_file.to_s, check)
     end
-    
+
     def set_working(work_dir, check = true)
       @lib = nil
       @working_directory = Git::WorkingDirectory.new(work_dir.to_s, check)
     end
-    
+
     # returns +true+ if the branch exists locally
     def is_local_branch?(branch)
       branch_names = self.branches.local.map {|b| b.name}
@@ -177,15 +177,15 @@ module Git
       branch_names.include?(branch)
     end
 
-    # this is a convenience method for accessing the class that wraps all the 
+    # this is a convenience method for accessing the class that wraps all the
     # actual 'git' forked system calls.  At some point I hope to replace the Git::Lib
     # class with one that uses native methods or libgit C bindings
     def lib
       @lib ||= Git::Lib.new(self, @logger)
     end
-    
+
     # will run a grep for 'string' on the HEAD of the git repository
-    # 
+    #
     # to be more surgical in your grep, you can call grep() off a specific
     # git object.  for example:
     #
@@ -206,7 +206,7 @@ module Git
     def grep(string, path_limiter = nil, opts = {})
       self.object('HEAD').grep(string, path_limiter, opts)
     end
-    
+
     # updates the repository index using the working directory content
     #
     #    @git.add('path/to/file')
@@ -282,7 +282,7 @@ module Git
     end
 
     # commits all pending changes in the index file to the git repository
-    # 
+    #
     # options:
     #   :all
     #   :allow_empty
@@ -292,10 +292,10 @@ module Git
     def commit(message, opts = {})
       self.lib.commit(message, opts)
     end
-        
+
     # commits all pending changes in the index file to the git repository,
     # but automatically adds all modified files without having to explicitly
-    # calling @git.add() on them.  
+    # calling @git.add() on them.
     def commit_all(message, opts = {})
       opts = {:add_all => true}.merge(opts)
       self.lib.commit(message, opts)
@@ -305,7 +305,7 @@ module Git
     def checkout(branch = 'master', opts = {})
       self.lib.checkout(branch, opts)
     end
-    
+
     # checks out an old version of a file
     def checkout_file(version, file)
       self.lib.checkout_file(version,file)
@@ -328,7 +328,14 @@ module Git
 
       self.lib.push(remote, branch, opts)
     end
-    
+
+    # aborts the current conflict resolution process, and try to reconstruct the pre-merge state.
+    # rauses an error if there are no umerged files
+    def abort_merge(branch, message = 'merge')
+      raise "nothing to abort - no unmerged files" if self.lib.unmerged.count == 0
+      self.lib.abort_merge
+    end
+
     # merges one or more branches into the current working branch
     #
     # you can specify more than one branch to merge by passing an array of branches
@@ -350,7 +357,7 @@ module Git
     def pull(remote='origin', branch='master')
 			self.lib.pull(remote, branch)
     end
-    
+
     # returns an array of Git:Remote objects
     def remotes
       self.lib.remotes.map { |r| Git::Remote.new(self, r) }
@@ -358,7 +365,7 @@ module Git
 
     # adds a new remote to this repository
     # url can be a git url or a Git::Base object if it's a local reference
-    # 
+    #
     #  @git.add_remote('scotts_git', 'git://repo.or.cz/rubygit.git')
     #  @git.fetch('scotts_git')
     #  @git.merge('scotts_git/master')
@@ -396,37 +403,37 @@ module Git
     #   :f             -> true
     #   :m | :message  -> String
     #   :s             -> true
-    #   
+    #
     def add_tag(name, *opts)
       self.lib.tag(name, *opts)
       self.tag(name)
     end
- 
-    # deletes a tag 
-    def delete_tag(name) 
+
+    # deletes a tag
+    def delete_tag(name)
       self.lib.tag(name, {:d => true})
     end
-    
+
     # creates an archive file of the given tree-ish
     def archive(treeish, file = nil, opts = {})
       self.object(treeish).archive(file, opts)
     end
-    
+
     # repacks the repository
     def repack
       self.lib.repack
     end
-    
+
     def gc
       self.lib.gc
     end
-    
+
     def apply(file)
       if File.exist?(file)
         self.lib.apply(file)
       end
     end
-    
+
     def apply_mail(file)
       self.lib.apply_mail(file) if File.exist?(file)
     end
@@ -439,9 +446,9 @@ module Git
     def show(objectish=nil, path=nil)
       self.lib.show(objectish, path)
     end
-    
+
     ## LOWER LEVEL INDEX OPERATIONS ##
-    
+
     def with_index(new_index) # :yields: new_index
       old_index = @index
       set_index(new_index, false)
@@ -449,10 +456,10 @@ module Git
       set_index(old_index)
       return_value
     end
-    
+
     def with_temp_index &blk
       # Workaround for JRUBY, since they handle the TempFile path different.
-      # MUST be improved to be safer and OS independent. 
+      # MUST be improved to be safer and OS independent.
       if RUBY_PLATFORM == 'java'
         temp_path = "/tmp/temp-index-#{(0...15).map{ ('a'..'z').to_a[rand(26)] }.join}"
       else
@@ -464,29 +471,29 @@ module Git
 
       with_index(temp_path, &blk)
     end
-    
+
     def checkout_index(opts = {})
       self.lib.checkout_index(opts)
     end
-    
+
     def read_tree(treeish, opts = {})
       self.lib.read_tree(treeish, opts)
     end
-    
+
     def write_tree
       self.lib.write_tree
     end
-    
+
     def write_and_commit_tree(opts = {})
       tree = write_tree
       commit_tree(tree, opts)
     end
-      
+
     def update_ref(branch, commit)
       branch(branch).update_ref(commit)
     end
-    
-    
+
+
     def ls_files(location=nil)
       self.lib.ls_files(location)
     end
@@ -494,14 +501,14 @@ module Git
     def with_working(work_dir) # :yields: the Git::WorkingDirectory
       return_value = false
       old_working = @working_directory
-      set_working(work_dir) 
+      set_working(work_dir)
       Dir.chdir work_dir do
         return_value = yield @working_directory
       end
       set_working(old_working)
       return_value
     end
-    
+
     def with_temp_working &blk
       tempfile = Tempfile.new("temp-workdir")
       temp_dir = tempfile.path
@@ -510,8 +517,8 @@ module Git
       Dir.mkdir(temp_dir, 0700)
       with_working(temp_dir, &blk)
     end
-    
-    
+
+
     # runs git rev-parse to convert the objectish to a full sha
     #
     #   @git.revparse("HEAD^^")
@@ -521,11 +528,11 @@ module Git
     def revparse(objectish)
       self.lib.revparse(objectish)
     end
-    
+
     def ls_tree(objectish)
       self.lib.ls_tree(objectish)
     end
-    
+
     def cat_file(objectish)
       self.lib.object_contents(objectish)
     end
@@ -534,7 +541,7 @@ module Git
     def current_branch
       self.lib.branch_current
     end
-    
+
   end
-  
+
 end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -658,6 +658,10 @@ module Git
       command('merge', arr_opts)
     end
 
+    def abort_merge
+      command('merge', ["--abort"])
+    end
+
     def unmerged
       unmerged = []
       command_lines('diff', ["--cached"]).each do |line|


### PR DESCRIPTION
Hi there,

Not sure if this repo is still maintained, but this PR adds new function to `Base` class - `abort_merge`, which basically executes `git merge --abort` under the hood. 

*Note* that it raises an exception if there are no merge conflicts to be aborted.